### PR TITLE
added console_script to pip install for easy gui entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,4 +38,6 @@ setuptools.setup(
 	classifiers=[
 		"Programming Language :: Python :: 3",
 		"License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-		"Operating System :: OS Independent"])
+		"Operating System :: OS Independent"],
+    entry_points={"console_scripts" : ["paramagpy=paramagpy.gui:run"]}
+    )


### PR DESCRIPTION
I thought the process of importing paramagpy and then running paramagpy.gui.run() was a bit cumbersome for the gui. This simplifies the process to just running `paramagpy` from the command line.

I tested this out in a venv on macosx using python 3.9. I forked your repository and pip installed using the updated setup.py file and it works great.